### PR TITLE
fix logical error in a key base level utility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt', 'r') as fh:
 with open('test-requirements.txt', 'r') as fh:
     test_dev_install = [l.rstrip('\n') for l in fh.readlines()]
 
-version = "0.0.9"
+version = "0.0.10"
 setup(
     name="lrmaCUX",
     version=version,


### PR DESCRIPTION
when re-trying FISS attempts, there's a logic bug that leads to repeated FISS call.
This fixes that.