### PR TITLE
Fixed numpy version to exclude incompatible 2.0 versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytz>=2024.1
 tqdm>=4.66.4
 
 scipy>=1.13.0
-numpy=1.26.4,<2.0
+numpy==1.26.4,<2.0
 pandas>=2.2.2
 
 matplotlib>=3.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ plotly>=5.22.0
 termcolor>=2.4.0
 ansi2html>=1.9.1
 xmltodict>=0.13.0
+
+pysam==0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ termcolor>=2.4.0
 ansi2html>=1.9.1
 xmltodict>=0.13.0
 
-pysam==0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytz>=2024.1
 tqdm>=4.66.4
 
 scipy>=1.13.0
-numpy>=1.26.4
+numpy=1.26.4,<2.0
 pandas>=2.2.2
 
 matplotlib>=3.8.4


### PR DESCRIPTION
The newest `>=2.0` releases of `numpy` break a bunch of stuff that we need (e.g. `matplotlib`).

This PR forces `pip` to stay below the `2.0` versions.